### PR TITLE
gRPC error created with Error instead of Msg

### DIFF
--- a/pkg/nerror.go
+++ b/pkg/nerror.go
@@ -105,7 +105,7 @@ func (ee *ExtendedError) ToGRPC() error {
 		return ee
 	}
 
-	status := status.New(code, ee.Msg)
+	status := status.New(code, ee.Error())
 
 	complexSt, err := status.WithDetails(
 		&errdetails.DebugInfo{


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?
when converting an Extended Error to a gRPC error, we use Error() instead of Msg to get more info about all the errors chain 

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the associated tickets?

#### Screenshots (if appropriate)

#### Questions
